### PR TITLE
[POST] ~/eventsの実装

### DIFF
--- a/it_life_api/cmd/main.go
+++ b/it_life_api/cmd/main.go
@@ -40,6 +40,7 @@ func main() {
 		})
 	})
 	engine.POST("/users", handler.CreateUser)
+	engine.POST("/events", handler.CreateEvent)
 
 	engine.Run(":8000")
 }

--- a/it_life_api/cmd/main.go
+++ b/it_life_api/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 		})
 	})
 	engine.POST("/users", handler.CreateUser)
-	engine.POST("/events", handler.CreateEvent)
+	engine.POST("/events", handler.CreateEvents)
 
 	engine.Run(":8000")
 }

--- a/it_life_api/internal/infrastructure/persistence/event.go
+++ b/it_life_api/internal/infrastructure/persistence/event.go
@@ -8,20 +8,20 @@ import (
 )
 
 type (
-	// UserPersistence is a persistence to preserve users.
+	// EventPersistence is a persistence to preserve events.
 	EventPersistence struct {
 		Connection *gorm.DB
 	}
 )
 
-// NewUserPersistence creates a new user persistence.
+// NewEventPersistence creates a new event persistence.
 func NewEventPersistence() repository.EventRepository {
 	return EventPersistence{
 		Connection: getDBConnection(),
 	}
 }
 
-// Create create a user.
+// Create create a event.
 func (eventPersistence EventPersistence) Create(event model.Event) (model.Event, error) {
 	result := eventPersistence.Connection.
 		Create(&event)

--- a/it_life_api/internal/infrastructure/persistence/event.go
+++ b/it_life_api/internal/infrastructure/persistence/event.go
@@ -1,0 +1,30 @@
+package persistence
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/rikuhatano09/it-life-api/pkg/domain/model"
+	"github.com/rikuhatano09/it-life-api/pkg/domain/repository"
+)
+
+type (
+	// UserPersistence is a persistence to preserve users.
+	EventPersistence struct {
+		Connection *gorm.DB
+	}
+)
+
+// NewUserPersistence creates a new user persistence.
+func NewEventPersistence() repository.EventRepository {
+	return EventPersistence{
+		Connection: getDBConnection(),
+	}
+}
+
+// Create create a user.
+func (eventPersistence EventPersistence) Create(event model.Event) (model.Event, error) {
+	result := eventPersistence.Connection.
+		Create(&event)
+
+	return event, result.Error
+}

--- a/it_life_api/internal/interfaces/handler/event.go
+++ b/it_life_api/internal/interfaces/handler/event.go
@@ -21,12 +21,12 @@ func CreateEvent(context *gin.Context) {
 		return
 	}
 
-	event, _, err := usecase.CreateEvent(requestBody)
+	events, err := usecase.CreateEvent(requestBody)
 	if err != nil {
 		context.JSON(http.StatusInternalServerError, gin.H{
 			"message": fmt.Sprintf("Internal server error: %s", err.Error()),
 		})
 		return
 	}
-	context.JSON(http.StatusOK, event)
+	context.JSON(http.StatusOK, events)
 }

--- a/it_life_api/internal/interfaces/handler/event.go
+++ b/it_life_api/internal/interfaces/handler/event.go
@@ -21,7 +21,7 @@ func CreateEvent(context *gin.Context) {
 		return
 	}
 
-	event, err := usecase.CreateEvent(requestBody)
+	event, _, err := usecase.CreateEvent(requestBody)
 	if err != nil {
 		context.JSON(http.StatusInternalServerError, gin.H{
 			"message": fmt.Sprintf("Internal server error: %s", err.Error()),

--- a/it_life_api/internal/interfaces/handler/event.go
+++ b/it_life_api/internal/interfaces/handler/event.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/rikuhatano09/it-life-api/pkg/domain/contract"
+	"github.com/rikuhatano09/it-life-api/pkg/usecase"
+)
+
+func CreateEvent(context *gin.Context) {
+	requestBody := contract.EventPostRequestBody{}
+
+	err := context.ShouldBindJSON(&requestBody)
+	if err != nil {
+		context.JSON(http.StatusBadRequest, gin.H{
+			"message": fmt.Sprintf("Bad request error: %s", err.Error()),
+		})
+		return
+	}
+
+	event, err := usecase.CreateEvent(requestBody)
+	if err != nil {
+		context.JSON(http.StatusInternalServerError, gin.H{
+			"message": fmt.Sprintf("Internal server error: %s", err.Error()),
+		})
+		return
+	}
+	context.JSON(http.StatusOK, event)
+}

--- a/it_life_api/internal/interfaces/handler/event.go
+++ b/it_life_api/internal/interfaces/handler/event.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rikuhatano09/it-life-api/pkg/usecase"
 )
 
-func CreateEvent(context *gin.Context) {
+func CreateEvents(context *gin.Context) {
 	requestBody := contract.EventPostRequestBody{}
 
 	err := context.ShouldBindJSON(&requestBody)
@@ -21,7 +21,7 @@ func CreateEvent(context *gin.Context) {
 		return
 	}
 
-	events, err := usecase.CreateEvent(requestBody)
+	events, err := usecase.CreateEvents(requestBody)
 	if err != nil {
 		context.JSON(http.StatusInternalServerError, gin.H{
 			"message": fmt.Sprintf("Internal server error: %s", err.Error()),

--- a/it_life_api/pkg/domain/contract/request.go
+++ b/it_life_api/pkg/domain/contract/request.go
@@ -14,14 +14,14 @@ type (
 type (
 	// EventPostRequestBody is request body for creating a event.
 	EventPostRequestBody struct {
-		UserId int64       `json:"userId"`
+		UserID uint64      `json:"userId"`
 		Date   string      `json:"date"`
 		Events []EventItem `json:"events"`
 	}
 )
 
 type (
-	// EventItem is event structure definition.
+	// EventItem is an element of events.
 	EventItem struct {
 		Name        string `json:"name"`
 		StartTime   string `json:"startTime"`

--- a/it_life_api/pkg/domain/contract/request.go
+++ b/it_life_api/pkg/domain/contract/request.go
@@ -10,3 +10,22 @@ type (
 		Company     string `json:"company"`
 	}
 )
+
+type (
+	// EventPostRequestBody is request body for creating a event.
+	EventPostRequestBody struct {
+		UserId int64  `json:"userId"`
+		Date   string `json:"date"`
+		Events EventItem
+	}
+)
+
+type (
+	// EventItem is event structure definition.
+	EventItem struct {
+		Name        string `json:"name"`
+		StartTime   string `json:"startTime"`
+		EndTime     string `json:"endTime"`
+		Description string `json:"description"`
+	}
+)

--- a/it_life_api/pkg/domain/contract/request.go
+++ b/it_life_api/pkg/domain/contract/request.go
@@ -14,9 +14,9 @@ type (
 type (
 	// EventPostRequestBody is request body for creating a event.
 	EventPostRequestBody struct {
-		UserId int64  `json:"userId"`
-		Date   string `json:"date"`
-		Events EventItem
+		UserId int64       `json:"userId"`
+		Date   string      `json:"date"`
+		Events []EventItem `json:"events"`
 	}
 )
 

--- a/it_life_api/pkg/domain/contract/request.go
+++ b/it_life_api/pkg/domain/contract/request.go
@@ -1,5 +1,7 @@
 package contract
 
+import "time"
+
 type (
 	// UserPostRequestBody is request body for creating a user.
 	UserPostRequestBody struct {
@@ -29,3 +31,21 @@ type (
 		Description string `json:"description"`
 	}
 )
+
+func (eventItem EventItem) GetStartsAt(date string) time.Time {
+	startsAt, err := time.Parse("2006/01/02 15:04", date+" "+eventItem.StartTime)
+	if err != nil {
+		// TODO: Custom error handling
+		panic(err)
+	}
+	return startsAt
+}
+
+func (eventItem EventItem) GetEndsAt(date string) time.Time {
+	endsAt, err := time.Parse("2006/01/02 15:04", date+" "+eventItem.EndTime)
+	if err != nil {
+		// TODO: Custom error handling
+		panic(err)
+	}
+	return endsAt
+}

--- a/it_life_api/pkg/domain/model/event.go
+++ b/it_life_api/pkg/domain/model/event.go
@@ -4,8 +4,8 @@ import "time"
 
 type (
 	Event struct {
-		ID          int64     `json:"id"`
-		UserID      int64     `json:"userId"`
+		ID          uint64    `json:"id"`
+		UserID      uint64    `json:"userId"`
 		Name        string    `json:"name"`
 		Description string    `json:"description"`
 		StartsAt    time.Time `json:"startsAt"`

--- a/it_life_api/pkg/domain/model/event.go
+++ b/it_life_api/pkg/domain/model/event.go
@@ -1,0 +1,14 @@
+package model
+
+import "time"
+
+type (
+	Event struct {
+		ID          int64     `json:"id"`
+		UserID      int64     `json:"userId"`
+		Name        string    `json:"name"`
+		Description string    `json:"description"`
+		StartsAt    time.Time `json:"startsAt"`
+		EndsAt      time.Time `json:"endsAt"`
+	}
+)

--- a/it_life_api/pkg/domain/repository/event.go
+++ b/it_life_api/pkg/domain/repository/event.go
@@ -1,0 +1,9 @@
+package repository
+
+import "github.com/rikuhatano09/it-life-api/pkg/domain/model"
+
+type (
+	EventRepository interface {
+		Create(model.Event) (model.Event, error)
+	}
+)

--- a/it_life_api/pkg/usecase/create_event.go
+++ b/it_life_api/pkg/usecase/create_event.go
@@ -20,7 +20,7 @@ func CreateEvent(requestBody contract.EventPostRequestBody) (contract.EventPostR
 
 	for i := 0; i < len(requestBody.Events); i++ {
 		event := model.Event{
-			UserID:      requestBody.UserId,
+			UserID:      requestBody.UserID,
 			Name:        requestBody.Events[i].Name,
 			Description: requestBody.Events[i].Description,
 			StartsAt:    StrToTime(requestBody.Date, requestBody.Events[i].StartTime),

--- a/it_life_api/pkg/usecase/create_event.go
+++ b/it_life_api/pkg/usecase/create_event.go
@@ -1,0 +1,34 @@
+package usecase
+
+import (
+	"time"
+
+	"github.com/rikuhatano09/it-life-api/internal/infrastructure/persistence"
+	"github.com/rikuhatano09/it-life-api/pkg/domain/contract"
+	"github.com/rikuhatano09/it-life-api/pkg/domain/model"
+)
+
+func StrToTime(day string, times string) time.Time {
+	str := day + times
+	parsedTime, _ := time.Parse("2000-01-01T00:00:00Z", str)
+
+	return parsedTime
+}
+
+func CreateEvent(requestBody contract.EventPostRequestBody) (model.Event, error) {
+	eventPersistence := persistence.NewEventPersistence()
+
+	event := model.Event{
+		UserID:      requestBody.UserId,
+		Name:        requestBody.Events.Name,
+		Description: requestBody.Events.Description,
+		StartsAt:    StrToTime(requestBody.Date, requestBody.Events.StartTime),
+		EndsAt:      StrToTime(requestBody.Date, requestBody.Events.EndTime),
+	}
+
+	event, err := eventPersistence.Create(event)
+	if err != nil {
+		return model.Event{}, err
+	}
+	return event, nil
+}

--- a/it_life_api/pkg/usecase/create_event.go
+++ b/it_life_api/pkg/usecase/create_event.go
@@ -1,36 +1,29 @@
 package usecase
 
 import (
-	"time"
-
 	"github.com/rikuhatano09/it-life-api/internal/infrastructure/persistence"
 	"github.com/rikuhatano09/it-life-api/pkg/domain/contract"
 	"github.com/rikuhatano09/it-life-api/pkg/domain/model"
 )
 
-func StrToTime(day string, times string) time.Time {
-	str := day + times
-	parsedTime, _ := time.Parse("2000-01-01T00:00:00Z", str)
-
-	return parsedTime
-}
-
-func CreateEvent(requestBody contract.EventPostRequestBody) (contract.EventPostRequestBody, model.Event, error) {
+func CreateEvent(requestBody contract.EventPostRequestBody) ([]model.Event, error) {
 	eventPersistence := persistence.NewEventPersistence()
+	events := []model.Event{}
 
-	for i := 0; i < len(requestBody.Events); i++ {
+	for _, eventItem := range requestBody.Events {
 		event := model.Event{
 			UserID:      requestBody.UserID,
-			Name:        requestBody.Events[i].Name,
-			Description: requestBody.Events[i].Description,
-			StartsAt:    StrToTime(requestBody.Date, requestBody.Events[i].StartTime),
-			EndsAt:      StrToTime(requestBody.Date, requestBody.Events[i].EndTime),
+			Name:        eventItem.Name,
+			Description: eventItem.Description,
+			StartsAt:    eventItem.GetStartsAt(requestBody.Date),
+			EndsAt:      eventItem.GetEndsAt(requestBody.Date),
 		}
 
 		event, err := eventPersistence.Create(event)
 		if err != nil {
-			return requestBody, model.Event{}, err
+			return []model.Event{}, err
 		}
+		events = append(events, event)
 	}
-	return requestBody, model.Event{}, nil
+	return events, nil
 }

--- a/it_life_api/pkg/usecase/create_event.go
+++ b/it_life_api/pkg/usecase/create_event.go
@@ -15,20 +15,22 @@ func StrToTime(day string, times string) time.Time {
 	return parsedTime
 }
 
-func CreateEvent(requestBody contract.EventPostRequestBody) (model.Event, error) {
+func CreateEvent(requestBody contract.EventPostRequestBody) (contract.EventPostRequestBody, model.Event, error) {
 	eventPersistence := persistence.NewEventPersistence()
 
-	event := model.Event{
-		UserID:      requestBody.UserId,
-		Name:        requestBody.Events.Name,
-		Description: requestBody.Events.Description,
-		StartsAt:    StrToTime(requestBody.Date, requestBody.Events.StartTime),
-		EndsAt:      StrToTime(requestBody.Date, requestBody.Events.EndTime),
-	}
+	for i := 0; i < len(requestBody.Events); i++ {
+		event := model.Event{
+			UserID:      requestBody.UserId,
+			Name:        requestBody.Events[i].Name,
+			Description: requestBody.Events[i].Description,
+			StartsAt:    StrToTime(requestBody.Date, requestBody.Events[i].StartTime),
+			EndsAt:      StrToTime(requestBody.Date, requestBody.Events[i].EndTime),
+		}
 
-	event, err := eventPersistence.Create(event)
-	if err != nil {
-		return model.Event{}, err
+		event, err := eventPersistence.Create(event)
+		if err != nil {
+			return requestBody, model.Event{}, err
+		}
 	}
-	return event, nil
+	return requestBody, model.Event{}, nil
 }

--- a/it_life_api/pkg/usecase/create_events.go
+++ b/it_life_api/pkg/usecase/create_events.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rikuhatano09/it-life-api/pkg/domain/model"
 )
 
-func CreateEvent(requestBody contract.EventPostRequestBody) ([]model.Event, error) {
+func CreateEvents(requestBody contract.EventPostRequestBody) ([]model.Event, error) {
 	eventPersistence := persistence.NewEventPersistence()
 	events := []model.Event{}
 


### PR DESCRIPTION
差分
・main.goにengine.POSTの追加
・persistence下にevent.goの作成
・handler下にevent.goの作成
・contract/request.goにevent構造体の作成
・model下にevent.goの作成
・repository下にevent.goの作成
・usecase下にcreate_event.goの作成

特筆点
・handler下に作成したevent.goで，usecase.CreateEventの返り値変更に基づいて変数を3つに変更．
・request.goで，event構造体が配列を持つことから，構造体を二つに分割．
・usecase下で作成したcreate_event.goで，StrToTime関数の作成．CreateEventの返り値を3つに変更．